### PR TITLE
PCQ_48_Nightly_build_fix Added suppression for false positive for log4j jar

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -345,4 +345,18 @@
     <sha1>c43f6e6bfa79b56e04a8898a923c3cf7144dd460</sha1>
     <cve>CVE-2017-7957</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: log4j-to-slf4j-2.12.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-to\-slf4j@.*$</packageUrl>
+    <cve>CVE-2020-9488</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: log4j-api-2.12.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
+    <cve>CVE-2020-9488</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ_48


### Change description ###
The nightly build was failing because of a dependency check on the log4j jars. This is a false positive as the vulnerability occurs in the SMTP appender which we are not using in the project.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
