### PR TITLE
Pcq 514 pcq without case new api

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -368,4 +368,11 @@
    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-(core|websocket)@.*$</packageUrl>
    <cve>CVE-2020-9484</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: postgresql-42.2.11.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
+    <cve>CVE-2020-13692</cve>
+  </suppress>
 </suppressions>

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/client/PcqBackEndServiceClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/client/PcqBackEndServiceClient.java
@@ -9,6 +9,7 @@ import net.serenitybdd.rest.SerenityRest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerRequest;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqRecordWithoutCaseResponse;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -195,6 +196,21 @@ public class PcqBackEndServiceClient {
             return null;
         }
         return response.body().as(Map.class);
+    }
+
+    public PcqRecordWithoutCaseResponse getAnswerRecordsWithoutCase(HttpStatus status) {
+
+        Response response = getCoRelationHeaders()
+            .get("pcq/backend/consolidation/pcqRecordWithoutCase")
+            .andReturn();
+        response.then()
+            .assertThat()
+            .statusCode(status.value());
+
+        if (status == HttpStatus.UNAUTHORIZED || status == INTERNAL_SERVER_ERROR) {
+            return null;
+        }
+        return response.body().as(PcqRecordWithoutCaseResponse.class);
     }
 
     public Map<String, Object> addCaseForPcq(String pcqId, String caseId, HttpStatus status) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqRecordWithoutCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqRecordWithoutCaseTest.java
@@ -1,0 +1,106 @@
+package uk.gov.hmcts.reform.pcqbackend.controllers;
+
+import lombok.extern.slf4j.Slf4j;
+import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerRequest;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerResponse;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqRecordWithoutCaseResponse;
+import uk.gov.hmcts.reform.pcqbackend.utils.ConversionUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringIntegrationSerenityRunner.class)
+@ActiveProfiles("functional")
+@Slf4j
+public class PcqRecordWithoutCaseTest extends PcqBaseFunctionalTest {
+
+    public static final String RESPONSE_KEY_1 = "pcqRecord";
+    public static final String RESPONSE_KEY_2 = "responseStatusCode";
+    public static final String RESPONSE_KEY_3 = "responseStatus";
+    public static final String HTTP_OK = "200";
+    public static final String HTTP_CREATED = "201";
+    public static final String RESPONSE_SUCCESS_MSG = "Success";
+    public static final String RESPONSE_CREATED_MSG = "Successfully created";
+    public static final int DAYS_LIMIT = 90;
+
+    private static final String STATUS_CODE_INVALID_MSG = "Response Status Code not valid";
+    private static final String STATUS_INVALID_MSG = "Response Status not valid";
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPcqRecordWithoutCase() {
+
+        try {
+
+            //Create 2 records in database with the current completed date.
+            String jsonStringRequest = jsonStringFromFile("JsonTestFiles/FirstSubmitAnswer.json");
+            PcqAnswerRequest answerRequest = jsonObjectFromString(jsonStringRequest);
+
+            String firstUuid = generateUuid();
+            answerRequest.setCompletedDate(updateCompletedDate(answerRequest.getCompletedDate()));
+            answerRequest.setPcqId(firstUuid);
+
+            Map<String, Object> response = pcqBackEndServiceClient.createAnswersRecord(answerRequest);
+
+            assertEquals(STATUS_CODE_INVALID_MSG, HTTP_CREATED, response.get(RESPONSE_KEY_2));
+            assertEquals(STATUS_INVALID_MSG, RESPONSE_CREATED_MSG,
+                         response.get(RESPONSE_KEY_3));
+
+            String secondUuid = generateUuid();
+            answerRequest.setPcqId(secondUuid);
+            answerRequest.setCompletedDate(updateCompletedDate(answerRequest.getCompletedDate()));
+
+            response = pcqBackEndServiceClient.createAnswersRecord(answerRequest);
+
+            assertEquals(STATUS_CODE_INVALID_MSG, HTTP_CREATED, response.get(RESPONSE_KEY_2));
+            assertEquals(STATUS_INVALID_MSG, RESPONSE_CREATED_MSG,
+                         response.get(RESPONSE_KEY_3));
+
+            //Create 3rd record in database with a completed date past the limit.
+            String thirdUuid = generateUuid();
+            answerRequest.setPcqId(thirdUuid);
+            answerRequest.setCompletedDate(ConversionUtil.convertTimeStampToString(ConversionUtil.getDateTimeInPast(
+                DAYS_LIMIT + 1)));
+
+            response = pcqBackEndServiceClient.createAnswersRecord(answerRequest);
+
+            assertEquals(STATUS_CODE_INVALID_MSG, HTTP_CREATED, response.get(RESPONSE_KEY_2));
+            assertEquals(STATUS_INVALID_MSG, RESPONSE_CREATED_MSG,
+                         response.get(RESPONSE_KEY_3));
+
+            //Now call the pcqWithoutCaseAPI
+            PcqRecordWithoutCaseResponse getResponse = pcqBackEndServiceClient.getAnswerRecordsWithoutCase(
+                HttpStatus.OK);
+
+
+            assertEquals(STATUS_CODE_INVALID_MSG, HTTP_OK, getResponse.getResponseStatusCode());
+            assertEquals(STATUS_INVALID_MSG, RESPONSE_SUCCESS_MSG, getResponse.getResponseStatus());
+
+            PcqAnswerResponse[] answerResponses = getResponse.getPcqRecord();
+            List<String> pcqIdsInResponse = new ArrayList<>(3);
+            for (PcqAnswerResponse answerResponse : answerResponses) {
+                pcqIdsInResponse.add(answerResponse.getPcqId());
+            }
+
+            assertTrue("First PCQ Id should have been picked up", pcqIdsInResponse.contains(firstUuid));
+            assertTrue("Second PCQ Id should have been picked up", pcqIdsInResponse.contains(secondUuid));
+            assertFalse("Third PCQ Id should not have been picked up", pcqIdsInResponse.contains(thirdUuid));
+
+
+        } catch (IOException e) {
+            log.error("Error during test execution", e);
+        }
+
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
@@ -177,11 +177,11 @@ public class GetPcqRecordWithoutCaseTest extends PcqIntegrationTest {
             pcqBackEndClient.createPcqAnswer(answerRequest);
 
             PcqAnswerRequest answerRequest2 = cloneAnswerObject(answerRequest,"INTEG-TEST-11", "PROBATE1",
-                                                                "PETITIONER");
+                                                                "APPLICANT");
             pcqBackEndClient.createPcqAnswer(answerRequest2);
 
             PcqAnswerRequest answerRequest3 = cloneAnswerObject(answerRequest, "INTEG-TEST-12", "DIVORCE",
-                                                                "APPLICANT");
+                                                                "PETITIONER");
             pcqBackEndClient.createPcqAnswer(answerRequest3);
 
             //Now call the actual method.

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
@@ -169,7 +169,6 @@ public class GetPcqRecordWithoutCaseTest extends PcqIntegrationTest {
     @Test
     public void getPcqRecordWithoutCaseMultipleIds() {
         try {
-            //******* DEBUG THIS ON MONDAY *********
 
             //Create the Test Data 3 times in the database.
             String jsonStringRequest = jsonStringFromFile(JSON_FILE);
@@ -177,12 +176,12 @@ public class GetPcqRecordWithoutCaseTest extends PcqIntegrationTest {
             answerRequest.setCompletedDate(updateCompletedDate(answerRequest.getCompletedDate()));
             pcqBackEndClient.createPcqAnswer(answerRequest);
 
-            PcqAnswerRequest answerRequest2 = answerRequest;
-            answerRequest2.setPcqId("INTEG-TEST-11");
+            PcqAnswerRequest answerRequest2 = cloneAnswerObject(answerRequest,"INTEG-TEST-11", "PROBATE1",
+                                                                "PETITIONER");
             pcqBackEndClient.createPcqAnswer(answerRequest2);
 
-            PcqAnswerRequest answerRequest3 = answerRequest;
-            answerRequest3.setPcqId("INTEG-TEST-12");
+            PcqAnswerRequest answerRequest3 = cloneAnswerObject(answerRequest, "INTEG-TEST-12", "DIVORCE",
+                                                                "APPLICANT");
             pcqBackEndClient.createPcqAnswer(answerRequest3);
 
             //Now call the actual method.
@@ -221,6 +220,22 @@ public class GetPcqRecordWithoutCaseTest extends PcqIntegrationTest {
             assertEquals("Service Id not found", pcqIds[i].getServiceId(), pcqRecordsActual[i].getServiceId());
             assertEquals("Actor not found", pcqIds[i].getActor(), pcqRecordsActual[i].getActor());
         }
+    }
+
+    private PcqAnswerRequest cloneAnswerObject(PcqAnswerRequest originalAnswer, String pcqId, String serviceId,
+                                               String actor) {
+        PcqAnswerRequest clonedAnswer = new PcqAnswerRequest();
+        clonedAnswer.setPcqId(pcqId);
+        clonedAnswer.setPartyId(originalAnswer.getPartyId());
+        clonedAnswer.setCompletedDate(originalAnswer.getCompletedDate());
+        clonedAnswer.setPcqAnswers(originalAnswer.getPcqAnswers());
+        clonedAnswer.setVersionNo(originalAnswer.getVersionNo());
+        clonedAnswer.setActor(actor);
+        clonedAnswer.setServiceId(serviceId);
+        clonedAnswer.setChannel(originalAnswer.getChannel());
+        clonedAnswer.setCaseId(originalAnswer.getCaseId());
+
+        return clonedAnswer;
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
@@ -1,0 +1,226 @@
+package uk.gov.hmcts.reform.pcqbackend.controllers;
+
+import lombok.extern.slf4j.Slf4j;
+import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerRequest;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerResponse;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqRecordWithoutCaseResponse;
+import uk.gov.hmcts.reform.pcqbackend.util.PcqIntegrationTest;
+import uk.gov.hmcts.reform.pcqbackend.utils.ConversionUtil;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Slf4j
+@RunWith(SpringIntegrationSerenityRunner.class)
+@SuppressWarnings("PMD.LinguisticNaming")
+public class GetPcqRecordWithoutCaseTest extends PcqIntegrationTest {
+
+    public static final String RESPONSE_KEY_1 = "pcqRecord";
+    public static final String RESPONSE_KEY_2 = "responseStatusCode";
+    public static final String RESPONSE_KEY_3 = "responseStatus";
+    public static final String HTTP_OK = "200";
+    public static final String RESPONSE_SUCCESS_MSG = "Success";
+    public static final String EXCEPTION_MSG = "Exception while executing test";
+
+    private static final String ASSERT_MESSAGE_PCQ = "PCQId not valid";
+    private static final String ASSERT_MESSAGE_STATUS = "Response Status not valid";
+    private static final String ASSERT_MESSAGE_STATUS_CODE = "Response Status Code not valid";
+    private static final int DAYS_LIMIT = 90;
+    private static final String JSON_FILE = "JsonTestFiles/FirstSubmitAnswer.json";
+
+    @Rule
+    public OutputCaptureRule capture = new OutputCaptureRule();
+
+    @Test
+    public void getPcqRecordWithoutCaseSingleRecord() {
+        try {
+
+            //Create the Test Data in the database.
+            String jsonStringRequest = jsonStringFromFile(JSON_FILE);
+            PcqAnswerRequest answerRequest = jsonObjectFromString(jsonStringRequest);
+            answerRequest.setCompletedDate(updateCompletedDate(answerRequest.getCompletedDate()));
+            pcqBackEndClient.createPcqAnswer(answerRequest);
+
+            //Now call the actual method.
+            Map<String, Object> responseMap = pcqBackEndClient.getPcqRecordWithoutCase();
+
+            //Test the assertions
+            assertTestForSuccess(responseMap, 1, answerRequest);
+            checkLogsForKeywords();
+
+
+        } catch (Exception e) {
+            log.error(EXCEPTION_MSG, e);
+        }
+
+    }
+
+    @Test
+    public void getPcqRecordWithoutCaseRecordNotFound() {
+        try {
+
+            //Create the Test Data in the database.
+            String jsonStringRequest = jsonStringFromFile("JsonTestFiles/FirstSubmitAnswerWithCase.json");
+            PcqAnswerRequest answerRequest = jsonObjectFromString(jsonStringRequest);
+            answerRequest.setCompletedDate(updateCompletedDate(answerRequest.getCompletedDate()));
+            pcqBackEndClient.createPcqAnswer(answerRequest);
+
+            //Now call the actual method.
+            Map<String, Object> responseMap = pcqBackEndClient.getPcqRecordWithoutCase();
+
+            //Test the assertions
+            assertTestForSuccess(responseMap, 0, answerRequest);
+            checkLogsForKeywords();
+
+
+        } catch (Exception e) {
+            log.error(EXCEPTION_MSG, e);
+        }
+
+    }
+
+    @Test
+    public void getPcqRecordWithoutCaseCompletedDatePastBoundary() {
+        try {
+
+            //Create the Test Data in the database.
+            String jsonStringRequest = jsonStringFromFile(JSON_FILE);
+            PcqAnswerRequest answerRequest = jsonObjectFromString(jsonStringRequest);
+            //Update the completed date to be in the past.
+            answerRequest.setCompletedDate(ConversionUtil.convertTimeStampToString(ConversionUtil.getDateTimeInPast(
+                DAYS_LIMIT + 1)));
+            pcqBackEndClient.createPcqAnswer(answerRequest);
+
+            //Now call the actual method.
+            Map<String, Object> responseMap = pcqBackEndClient.getPcqRecordWithoutCase();
+
+            //Test the assertions
+            assertTestForSuccess(responseMap, 0, answerRequest);
+            checkLogsForKeywords();
+
+
+        } catch (Exception e) {
+            log.error(EXCEPTION_MSG, e);
+        }
+
+    }
+
+    @Test
+    public void getPcqRecordWithoutCaseCompletedDateOnBoundary() {
+        try {
+
+            //Create the Test Data in the database.
+            String jsonStringRequest = jsonStringFromFile(JSON_FILE);
+            PcqAnswerRequest answerRequest = jsonObjectFromString(jsonStringRequest);
+            //Update the completed date to be in the past.
+            answerRequest.setCompletedDate(ConversionUtil.convertTimeStampToString(ConversionUtil.getDateTimeInPast(
+                DAYS_LIMIT)));
+            pcqBackEndClient.createPcqAnswer(answerRequest);
+
+            //Now call the actual method.
+            Map<String, Object> responseMap = pcqBackEndClient.getPcqRecordWithoutCase();
+
+            //Test the assertions
+            assertTestForSuccess(responseMap, 0, answerRequest);
+            checkLogsForKeywords();
+
+
+        } catch (Exception e) {
+            log.error(EXCEPTION_MSG, e);
+        }
+
+    }
+
+    @Test
+    public void getPcqRecordWithoutCaseCompletedDatePreBoundary() {
+        try {
+
+            //Create the Test Data in the database.
+            String jsonStringRequest = jsonStringFromFile(JSON_FILE);
+            PcqAnswerRequest answerRequest = jsonObjectFromString(jsonStringRequest);
+            //Update the completed date to be in the past.
+            answerRequest.setCompletedDate(ConversionUtil.convertTimeStampToString(ConversionUtil.getDateTimeInPast(
+                DAYS_LIMIT - 1)));
+            pcqBackEndClient.createPcqAnswer(answerRequest);
+
+            //Now call the actual method.
+            Map<String, Object> responseMap = pcqBackEndClient.getPcqRecordWithoutCase();
+
+            //Test the assertions
+            assertTestForSuccess(responseMap, 1, answerRequest);
+            checkLogsForKeywords();
+
+
+        } catch (Exception e) {
+            log.error(EXCEPTION_MSG, e);
+        }
+
+    }
+
+    @Test
+    public void getPcqRecordWithoutCaseMultipleIds() {
+        try {
+            //******* DEBUG THIS ON MONDAY *********
+
+            //Create the Test Data 3 times in the database.
+            String jsonStringRequest = jsonStringFromFile(JSON_FILE);
+            PcqAnswerRequest answerRequest = jsonObjectFromString(jsonStringRequest);
+            answerRequest.setCompletedDate(updateCompletedDate(answerRequest.getCompletedDate()));
+            pcqBackEndClient.createPcqAnswer(answerRequest);
+
+            PcqAnswerRequest answerRequest2 = answerRequest;
+            answerRequest2.setPcqId("INTEG-TEST-11");
+            pcqBackEndClient.createPcqAnswer(answerRequest2);
+
+            PcqAnswerRequest answerRequest3 = answerRequest;
+            answerRequest3.setPcqId("INTEG-TEST-12");
+            pcqBackEndClient.createPcqAnswer(answerRequest3);
+
+            //Now call the actual method.
+            Map<String, Object> responseMap = pcqBackEndClient.getPcqRecordWithoutCase();
+
+            //Test the assertions
+            assertTestForSuccess(responseMap, 3, answerRequest, answerRequest2, answerRequest3);
+            checkLogsForKeywords();
+
+
+        } catch (Exception e) {
+            log.error(EXCEPTION_MSG, e);
+        }
+
+    }
+
+
+    private void checkLogsForKeywords() {
+        assertTrue(capture.getAll().contains("Co-Relation Id : " + CO_RELATION_ID_FOR_TEST),
+                   "Co-Relation Id was not logged in log files.");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertTestForSuccess(Map<String, Object> responseMap, int recordsExpected,
+                                      PcqAnswerRequest... pcqIds) {
+        ResponseEntity<PcqRecordWithoutCaseResponse> response = (ResponseEntity<PcqRecordWithoutCaseResponse>)
+            responseMap.get("response_body");
+        assertNotNull(response.getBody().getPcqRecord(), ASSERT_MESSAGE_PCQ);
+        assertEquals(ASSERT_MESSAGE_STATUS_CODE, HTTP_OK, response.getBody().getResponseStatusCode());
+        assertEquals(ASSERT_MESSAGE_STATUS, RESPONSE_SUCCESS_MSG, response.getBody().getResponseStatus());
+        PcqAnswerResponse[] pcqRecordsActual = response.getBody().getPcqRecord();
+        assertEquals("Pcq Records size not matching", recordsExpected, pcqRecordsActual.length);
+
+        for (int i = 0; i < pcqRecordsActual.length; i++) {
+            assertEquals("Pcq Id not found", pcqIds[i].getPcqId(), pcqRecordsActual[i].getPcqId());
+            assertEquals("Service Id not found", pcqIds[i].getServiceId(), pcqRecordsActual[i].getServiceId());
+            assertEquals("Actor not found", pcqIds[i].getActor(), pcqRecordsActual[i].getActor());
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcqbackend/model/PcqRecordWithoutCaseResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqbackend/model/PcqRecordWithoutCaseResponse.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.pcqbackend.model;
+
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * This is the object representing the REST response for the PcqRecordWithoutACase API.
+ */
+@NoArgsConstructor
+public class PcqRecordWithoutCaseResponse implements Serializable {
+
+    public static final long serialVersionUID = 432943329;
+
+    private PcqAnswerResponse[] pcqRecord;
+
+    private String responseStatus;
+
+    private String responseStatusCode;
+
+    public PcqAnswerResponse[] getPcqRecord() {
+        if (pcqRecord == null) {
+            return null;
+        }
+        return Arrays.copyOf(pcqRecord, pcqRecord.length);
+    }
+
+    @SuppressWarnings("PMD.UseVarargs")
+    public void setPcqRecord(PcqAnswerResponse[] pcqRecord) {
+        if (pcqRecord == null) {
+            this.pcqRecord = new PcqAnswerResponse[0];
+        } else {
+            this.pcqRecord = Arrays.copyOf(pcqRecord, pcqRecord.length);
+        }
+    }
+
+    public String getResponseStatus() {
+        return responseStatus;
+    }
+
+    public void setResponseStatus(String responseStatus) {
+        this.responseStatus = responseStatus;
+    }
+
+    public String getResponseStatusCode() {
+        return responseStatusCode;
+    }
+
+    public void setResponseStatusCode(String responseStatusCode) {
+        this.responseStatusCode = responseStatusCode;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pcqbackend/utils/ConversionUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqbackend/utils/ConversionUtil.java
@@ -229,7 +229,7 @@ public final class ConversionUtil {
 
         List<PcqAnswerResponse> pcqRecordArray = new ArrayList<>(pcqIds.size());
         for (ProtectedCharacteristics protectedCharacteristics : pcqIds) {
-            pcqRecordArray.add(createPcqRecord(protectedCharacteristics));
+            pcqRecordArray.add(createPcqRecordForConsolidationService(protectedCharacteristics));
         }
         pcqRecordWithoutCaseResponse.setPcqRecord(pcqRecordArray.toArray(new PcqAnswerResponse[0]));
         pcqRecordWithoutCaseResponse.setResponseStatus(message);
@@ -250,7 +250,7 @@ public final class ConversionUtil {
 
     }
 
-    private static PcqAnswerResponse createPcqRecord(ProtectedCharacteristics pcqDbRecord) {
+    private static PcqAnswerResponse createPcqRecordForConsolidationService(ProtectedCharacteristics pcqDbRecord) {
         PcqAnswerResponse answerResponse = new PcqAnswerResponse();
         answerResponse.setPcqId(pcqDbRecord.getPcqId());
         answerResponse.setServiceId(pcqDbRecord.getServiceId());

--- a/src/main/java/uk/gov/hmcts/reform/pcqbackend/utils/ConversionUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqbackend/utils/ConversionUtil.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.pcqbackend.exceptions.InvalidRequestException;
 import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerRequest;
 import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerResponse;
 import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswers;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqRecordWithoutCaseResponse;
 import uk.gov.hmcts.reform.pcqbackend.model.PcqWithoutCaseResponse;
 import uk.gov.hmcts.reform.pcqbackend.model.SubmitResponse;
 
@@ -216,6 +217,27 @@ public final class ConversionUtil {
         return new ResponseEntity<>(pcqWithoutCaseResponse, code);
     }
 
+    public static ResponseEntity<PcqRecordWithoutCaseResponse> generatePcqRecordWithoutCaseResponse(
+        List<ProtectedCharacteristics> pcqIds, HttpStatus code, String message) {
+        PcqRecordWithoutCaseResponse pcqRecordWithoutCaseResponse = new PcqRecordWithoutCaseResponse();
+        if (pcqIds == null) {
+            pcqRecordWithoutCaseResponse.setResponseStatus(message);
+            pcqRecordWithoutCaseResponse.setResponseStatusCode(String.valueOf(code.value()));
+
+            return new ResponseEntity<>(pcqRecordWithoutCaseResponse, code);
+        }
+
+        List<PcqAnswerResponse> pcqRecordArray = new ArrayList<>(pcqIds.size());
+        for (ProtectedCharacteristics protectedCharacteristics : pcqIds) {
+            pcqRecordArray.add(createPcqRecord(protectedCharacteristics));
+        }
+        pcqRecordWithoutCaseResponse.setPcqRecord(pcqRecordArray.toArray(new PcqAnswerResponse[0]));
+        pcqRecordWithoutCaseResponse.setResponseStatus(message);
+        pcqRecordWithoutCaseResponse.setResponseStatusCode(String.valueOf(code.value()));
+
+        return new ResponseEntity<>(pcqRecordWithoutCaseResponse, code);
+    }
+
     public static String validateRequestHeader(List<String> requestHeaders) throws InvalidRequestException {
 
         // Validate that the request contains the required Header values.
@@ -226,6 +248,14 @@ public final class ConversionUtil {
 
         return requestHeaders.get(0);
 
+    }
+
+    private static PcqAnswerResponse createPcqRecord(ProtectedCharacteristics pcqDbRecord) {
+        PcqAnswerResponse answerResponse = new PcqAnswerResponse();
+        answerResponse.setPcqId(pcqDbRecord.getPcqId());
+        answerResponse.setServiceId(pcqDbRecord.getServiceId());
+        answerResponse.setActor(pcqDbRecord.getActor());
+        return answerResponse;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcqbackend/controllers/ConsolidationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcqbackend/controllers/ConsolidationControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.pcqbackend.domain.ProtectedCharacteristics;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqAnswerResponse;
+import uk.gov.hmcts.reform.pcqbackend.model.PcqRecordWithoutCaseResponse;
 import uk.gov.hmcts.reform.pcqbackend.model.PcqWithoutCaseResponse;
 import uk.gov.hmcts.reform.pcqbackend.model.SubmitResponse;
 import uk.gov.hmcts.reform.pcqbackend.repository.ProtectedCharacteristicsRepository;
@@ -58,6 +60,11 @@ public class ConsolidationControllerTest {
     private static final String UNEXPECTED_RESPONSE_MSG = "Not expected response";
     private static final String SUCCESS_MSG = "Success";
     private static final String HTTP_OK = "200";
+    private static final String DAYS_LIMIT = "90";
+    private static final String UNKNOWN_ERROR_MSG = "Unknown error occurred";
+    private static final String EXPECTED_NOT_FOUND_MSG = "Expected 400 status code";
+    private static final String HTTP_NOT_FOUND = "400";
+    private static final String EXPECTED_400_MSG = "Expected 400 status";
 
     @BeforeEach
     public void setUp() {
@@ -73,7 +80,7 @@ public class ConsolidationControllerTest {
         when(environment.getProperty(INVALID_ERROR_PROPERTY)).thenReturn(INVALID_ERROR);
         when(environment.getProperty(UPDATE_MSG_PROPERTY)).thenReturn(API_ERROR_MESSAGE_UPDATED);
         when(environment.getProperty("api-error-messages.accepted")).thenReturn(SUCCESS_MSG);
-        when(environment.getProperty("api-error-messages.internal_error")).thenReturn("Unknown error occurred");
+        when(environment.getProperty("api-error-messages.internal_error")).thenReturn(UNKNOWN_ERROR_MSG);
     }
 
     /**
@@ -93,10 +100,10 @@ public class ConsolidationControllerTest {
             ResponseEntity<PcqWithoutCaseResponse> actual = consolidationController.getPcqIdsWithoutCase(mockHeaders);
 
             assertNotNull(actual, RESPONSE_NULL_MSG);
-            assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode(), "Expected 400 status code");
+            assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode(), EXPECTED_NOT_FOUND_MSG);
 
             PcqWithoutCaseResponse actualBody = actual.getBody();
-            assertEquals("400", actualBody.getResponseStatusCode(), "Expected 400 status");
+            assertEquals(HTTP_NOT_FOUND, actualBody.getResponseStatusCode(), EXPECTED_400_MSG);
             assertEquals(API_ERROR_MESSAGE_BAD_REQUEST, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
 
             verify(mockHeaders, times(1)).get(HEADER_KEY);
@@ -121,7 +128,7 @@ public class ConsolidationControllerTest {
             when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
             HttpHeaders mockHeaders = getMockHeader();
             when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
-            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn("90");
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
 
             List<ProtectedCharacteristics> targetList = generateTargetList(3);
             when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
@@ -164,7 +171,7 @@ public class ConsolidationControllerTest {
             when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
             HttpHeaders mockHeaders = getMockHeader();
             when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
-            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn("90");
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
 
             List<ProtectedCharacteristics> targetList = generateTargetList(1);
             when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
@@ -206,7 +213,7 @@ public class ConsolidationControllerTest {
             when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
             HttpHeaders mockHeaders = getMockHeader();
             when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
-            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn("90");
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
 
             List<ProtectedCharacteristics> targetList = generateTargetList(0);
             when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
@@ -249,7 +256,7 @@ public class ConsolidationControllerTest {
             when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
             HttpHeaders mockHeaders = getMockHeader();
             when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
-            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn("90");
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
 
             when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
                 Timestamp.class))).thenThrow(NullPointerException.class);
@@ -262,7 +269,7 @@ public class ConsolidationControllerTest {
             PcqWithoutCaseResponse actualBody = actual.getBody();
             assertNotNull(actualBody, BODY_NULL_MSG);
             assertEquals("500", actualBody.getResponseStatusCode(), "Expected 500 status");
-            assertEquals("Unknown error occurred", actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
+            assertEquals(UNKNOWN_ERROR_MSG, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
             assertNull(actualBody.getPcqId(), "PcqIds are null");
             List<ProtectedCharacteristics> targetList = generateTargetList(0);
             assertArrayContents(targetList, actualBody.getPcqId());
@@ -297,10 +304,10 @@ public class ConsolidationControllerTest {
                                                                                           TEST_CASE_ID);
 
             assertNotNull(actual, RESPONSE_NULL_MSG);
-            assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode(), "Expected 400 status code");
+            assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode(), EXPECTED_NOT_FOUND_MSG);
 
             SubmitResponse actualBody = actual.getBody();
-            assertEquals("400", actualBody.getResponseStatusCode(), "Expected 400 status");
+            assertEquals(HTTP_NOT_FOUND, actualBody.getResponseStatusCode(), EXPECTED_400_MSG);
             assertEquals(API_ERROR_MESSAGE_BAD_REQUEST, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
 
             verify(mockHeaders, times(1)).get(HEADER_KEY);
@@ -367,11 +374,11 @@ public class ConsolidationControllerTest {
             ResponseEntity<SubmitResponse> actual = consolidationController.addCaseForPcq(mockHeaders, TEST_PCQ_ID,
                                                                                           TEST_CASE_ID);
             assertNotNull(actual, RESPONSE_NULL_MSG);
-            assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode(), "Expected 400 status code");
+            assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode(), EXPECTED_NOT_FOUND_MSG);
 
             SubmitResponse actualBody = actual.getBody();
             assertNotNull(actualBody, BODY_NULL_MSG);
-            assertEquals("400", actualBody.getResponseStatusCode(), "Expected 400 status");
+            assertEquals(HTTP_NOT_FOUND, actualBody.getResponseStatusCode(), EXPECTED_400_MSG);
             assertEquals(API_ERROR_MESSAGE_BAD_REQUEST, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
             assertNotNull(actualBody.getPcqId(), "PcqIds are not null");
 
@@ -410,7 +417,7 @@ public class ConsolidationControllerTest {
             SubmitResponse actualBody = actual.getBody();
             assertNotNull(actualBody, BODY_NULL_MSG);
             assertEquals("500", actualBody.getResponseStatusCode(), "Expected 500 status");
-            assertEquals("Unknown error occurred", actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
+            assertEquals(UNKNOWN_ERROR_MSG, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
 
             verify(mockHeaders, times(1)).get(HEADER_KEY);
             verify(environment, times(1)).getProperty(HEADER_API_PROPERTY);
@@ -419,6 +426,215 @@ public class ConsolidationControllerTest {
 
         } catch (Exception e) {
             fail(ERROR_MSG_PREFIX + e.getMessage());
+        }
+
+    }
+
+    /**
+     * This method tests the getPcqRecordWithoutCase API when it is called with all valid parameters but the
+     * header does not contain the required attribute. The response status code will be 400.
+     */
+    @DisplayName("Should return with an Invalid Request error code 400")
+    @Test
+    public void testGetPcqRecordWithoutCaseForMissingHeader()  {
+
+        try {
+
+            when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
+            HttpHeaders mockHeaders = mock(HttpHeaders.class);
+            when(mockHeaders.get(HEADER_KEY)).thenReturn(null);
+
+            ResponseEntity<PcqRecordWithoutCaseResponse> actual = consolidationController.getPcqRecordWithoutCase(
+                mockHeaders);
+
+            assertNotNull(actual, RESPONSE_NULL_MSG);
+            assertEquals(HttpStatus.BAD_REQUEST, actual.getStatusCode(), EXPECTED_NOT_FOUND_MSG);
+
+            PcqRecordWithoutCaseResponse actualBody = actual.getBody();
+            assertEquals(HTTP_NOT_FOUND, actualBody.getResponseStatusCode(), EXPECTED_400_MSG);
+            assertEquals(API_ERROR_MESSAGE_BAD_REQUEST, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
+
+            verify(mockHeaders, times(1)).get(HEADER_KEY);
+            verify(environment, times(1)).getProperty(HEADER_API_PROPERTY);
+
+        } catch (Exception e) {
+            fail(ERROR_MSG_PREFIX + e.getMessage());
+        }
+
+    }
+
+    /**
+     * This method tests the getPcqRecordWithoutCase API when it is called with all valid parameters and
+     * the response contains multiple pcq records. The response status code will be 200.
+     */
+    @DisplayName("Should return with an Success Request error code 200 and multiple pcq records")
+    @Test
+    public void testGetPcqRecordWithoutCaseMultipleIds()  {
+
+        try {
+
+            when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
+            HttpHeaders mockHeaders = getMockHeader();
+            when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
+
+            List<ProtectedCharacteristics> targetList = generateTargetList(3);
+            when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
+                Timestamp.class))).thenReturn(targetList);
+
+            ResponseEntity<PcqRecordWithoutCaseResponse> actual = consolidationController.getPcqRecordWithoutCase(
+                mockHeaders);
+
+            assertNotNull(actual, RESPONSE_NULL_MSG);
+            assertEquals(HttpStatus.OK, actual.getStatusCode(), STATUS_CODE_MSG);
+
+            PcqRecordWithoutCaseResponse actualBody = actual.getBody();
+            assertNotNull(actualBody, BODY_NULL_MSG);
+            assertEquals(HTTP_OK, actualBody.getResponseStatusCode(), MSG_1);
+            assertEquals(SUCCESS_MSG, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
+            assertNotNull(actualBody.getPcqRecord(), "PcqRecords are null");
+            assertArrayContents(targetList, actualBody.getPcqRecord());
+
+            verify(mockHeaders, times(1)).get(HEADER_KEY);
+            verify(environment, times(1)).getProperty(HEADER_API_PROPERTY);
+            verify(environment, times(1)).getProperty(NUMBER_OF_DAYS_PROPERTY);
+            verify(protectedCharacteristicsRepository, times(1))
+                .findByCaseIdIsNullAndCompletedDateGreaterThan(any(Timestamp.class));
+
+        } catch (Exception e) {
+            fail(ERROR_MSG_PREFIX + e.getMessage());
+        }
+
+    }
+
+    /**
+     * This method tests the getPcqRecordWithoutCase API when it is called with all valid parameters and
+     * the response contains array with single pcq record. The response status code will be 200.
+     */
+    @DisplayName("Should return with an Success Request error code 200 and single pcq record")
+    @Test
+    public void testGetPcqRecordWithoutCaseSingleId()  {
+
+        try {
+
+            when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
+            HttpHeaders mockHeaders = getMockHeader();
+            when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
+
+            List<ProtectedCharacteristics> targetList = generateTargetList(1);
+            when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
+                Timestamp.class))).thenReturn(targetList);
+
+            ResponseEntity<PcqRecordWithoutCaseResponse> actual = consolidationController.getPcqRecordWithoutCase(
+                mockHeaders);
+
+            assertNotNull(actual, RESPONSE_NULL_MSG);
+            assertEquals(HttpStatus.OK, actual.getStatusCode(), STATUS_CODE_MSG);
+
+            PcqRecordWithoutCaseResponse actualBody = actual.getBody();
+            assertNotNull(actualBody, BODY_NULL_MSG);
+            assertEquals(HTTP_OK, actualBody.getResponseStatusCode(), MSG_1);
+            assertEquals(SUCCESS_MSG, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
+            assertNotNull(actualBody.getPcqRecord(), "Pcq Record are not null");
+            assertArrayContents(targetList, actualBody.getPcqRecord());
+
+            verify(mockHeaders, times(1)).get(HEADER_KEY);
+            verify(environment, times(1)).getProperty(HEADER_API_PROPERTY);
+            verify(environment, times(1)).getProperty(NUMBER_OF_DAYS_PROPERTY);
+            verify(protectedCharacteristicsRepository, times(1))
+                .findByCaseIdIsNullAndCompletedDateGreaterThan(any(Timestamp.class));
+
+        } catch (Exception e) {
+            fail(ERROR_MSG_PREFIX + e.getMessage());
+        }
+
+    }
+
+    /**
+     * This method tests the getPcqRecordWithoutCase API when it is called with all valid parameters and
+     * the response contains empty array (no pcq records). The response status code will be 200.
+     */
+    @DisplayName("Should return with an Success Request error code 200 and no pcq ids")
+    @Test
+    public void testGetPcqRecordWithoutCaseNoPcqRecords()  {
+
+        try {
+
+            when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
+            HttpHeaders mockHeaders = getMockHeader();
+            when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
+
+            List<ProtectedCharacteristics> targetList = generateTargetList(0);
+            when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
+                Timestamp.class))).thenReturn(targetList);
+
+            ResponseEntity<PcqRecordWithoutCaseResponse> actual = consolidationController.getPcqRecordWithoutCase(
+                mockHeaders);
+
+            assertNotNull(actual, RESPONSE_NULL_MSG);
+            assertEquals(HttpStatus.OK, actual.getStatusCode(), STATUS_CODE_MSG);
+
+            PcqRecordWithoutCaseResponse actualBody = actual.getBody();
+            assertNotNull(actualBody, BODY_NULL_MSG);
+            assertEquals(HTTP_OK, actualBody.getResponseStatusCode(), MSG_1);
+            assertEquals(SUCCESS_MSG, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
+            assertNotNull(actualBody.getPcqRecord(), "Pcq Records are null");
+            assertArrayContents(targetList, actualBody.getPcqRecord());
+
+            verify(mockHeaders, times(1)).get(HEADER_KEY);
+            verify(environment, times(1)).getProperty(HEADER_API_PROPERTY);
+            verify(environment, times(1)).getProperty(NUMBER_OF_DAYS_PROPERTY);
+            verify(protectedCharacteristicsRepository, times(1))
+                .findByCaseIdIsNullAndCompletedDateGreaterThan(any(Timestamp.class));
+
+        } catch (Exception e) {
+            fail(ERROR_MSG_PREFIX + e.getMessage());
+        }
+
+    }
+
+    /**
+     * This method tests the getPcqRecordWithoutCase API when it is called with all valid parameters and
+     * but unforeseen error occurs. The response status code will be 500.
+     */
+    @DisplayName("Should return with an Unrecoverable Request error code 500 and no pcq ids")
+    @Test
+    public void testGetPcqRecordWithoutCaseInternalError()  {
+
+        try {
+
+            when(environment.getProperty(HEADER_API_PROPERTY)).thenReturn(HEADER_KEY);
+            HttpHeaders mockHeaders = getMockHeader();
+            when(mockHeaders.get(HEADER_KEY)).thenReturn(getTestHeader());
+            when(environment.getProperty(NUMBER_OF_DAYS_PROPERTY)).thenReturn(DAYS_LIMIT);
+
+            when(protectedCharacteristicsRepository.findByCaseIdIsNullAndCompletedDateGreaterThan(any(
+                Timestamp.class))).thenThrow(NullPointerException.class);
+
+            ResponseEntity<PcqRecordWithoutCaseResponse> actual = consolidationController.getPcqRecordWithoutCase(
+                mockHeaders);
+
+            assertNotNull(actual, RESPONSE_NULL_MSG);
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, actual.getStatusCode(), "Expected 500 status code");
+
+            PcqRecordWithoutCaseResponse actualBody = actual.getBody();
+            assertNotNull(actualBody, BODY_NULL_MSG);
+            assertEquals("500", actualBody.getResponseStatusCode(), "Expected 500 status");
+            assertEquals(UNKNOWN_ERROR_MSG, actualBody.getResponseStatus(), UNEXPECTED_RESPONSE_MSG);
+            assertNull(actualBody.getPcqRecord(), "Pcq Records are null");
+            List<ProtectedCharacteristics> targetList = generateTargetList(0);
+            assertArrayContents(targetList, actualBody.getPcqRecord());
+
+            verify(mockHeaders, times(1)).get(HEADER_KEY);
+            verify(environment, times(1)).getProperty(HEADER_API_PROPERTY);
+            verify(environment, times(1)).getProperty(NUMBER_OF_DAYS_PROPERTY);
+            verify(protectedCharacteristicsRepository, times(1))
+                .findByCaseIdIsNullAndCompletedDateGreaterThan(any(Timestamp.class));
+
+        } catch (Exception e) {
+            fail(ERROR_MSG_PREFIX + e.getMessage(), e);
         }
 
     }
@@ -443,6 +659,8 @@ public class ConsolidationControllerTest {
         for (int i = 0; i < rowCount; i++) {
             ProtectedCharacteristics targetObj = new ProtectedCharacteristics();
             targetObj.setPcqId("TEST - " + i);
+            targetObj.setServiceId("TEST_SERVICE_" + i);
+            targetObj.setActor("TEST_ACTOR_" + i);
             targetList.add(targetObj);
         }
 
@@ -450,9 +668,18 @@ public class ConsolidationControllerTest {
     }
 
     public static void assertArrayContents(List<ProtectedCharacteristics> targetList,
-                                          String... actualList) {
+                                           String... actualList) {
         for (int i = 0; i < targetList.size(); i++) {
             assertEquals(targetList.get(i).getPcqId(), actualList[i], "Pcq Id is not matching");
+        }
+    }
+
+    public static void assertArrayContents(List<ProtectedCharacteristics> targetList,
+                                          PcqAnswerResponse... actualList) {
+        for (int i = 0; i < targetList.size(); i++) {
+            assertEquals(targetList.get(i).getPcqId(), actualList[i].getPcqId(), "Pcq Id is not matching");
+            assertEquals(targetList.get(i).getServiceId(), actualList[i].getServiceId(), "Service Id is not matching");
+            assertEquals(targetList.get(i).getActor(), actualList[i].getActor(), "Actor is not matching");
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ-514


### Change description ###
A new API - pcqRecordWithoutCase - has been introduced. This API is based on the pcqWithoutCase but will now return service id and actor information. The existing APIs are unchanged. The change also includes unit tests, integration test and functional test.
In addition, a false positive for OWASP dependency check has been suppressed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
