### PR TITLE
PCQ-514_Added suppression for false positive for the new API

### DIFF
--- a/audit.json
+++ b/audit.json
@@ -23,5 +23,7 @@
   "100000_A Client Error response code was returned by the server_http://pcq-backend-aat.service.core-compute-aat.internal/pcq/backend/submitAnswers_POST": "ignore",
   "100000_A Client Error response code was returned by the server_http://pcq-backend-aat.service.core-compute-aat.internal/pcq/backend/consolidation/addCaseForPCQ/pcqId_PUT": "ignore",
   "100000_A Client Error response code was returned by the server_http://pcq-backend-aat.service.core-compute-aat.internal/pcq/backend/getAnswer/pcqId_GET": "ignore",
-  "100000_A Client Error response code was returned by the server_http://pcq-backend-aat.service.core-compute-aat.internal/pcq/backend/consolidation/pcqWithoutCase_GET": "ignore"
+  "100000_A Client Error response code was returned by the server_http://pcq-backend-aat.service.core-compute-aat.internal/pcq/backend/consolidation/pcqWithoutCase_GET": "ignore",
+  "100000_A Client Error response code was returned by the server_http://pcq-backend-aat.service.core-compute-aat.internal/pcq/backend/consolidation/pcqRecordWithoutCase_GET": "ignore"
 }
+


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ-514


### Change description ###
The nightly pcq-backend build fails at the security scan stage with an low alert for the new pcqRecordWithoutCase API. This is a false positive and a similar suppression rule already exists for the pcqWithoutCase API. The same suppression rule has been added in the audit.json for the new API.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
