### PR TITLE
PCQ-636: Serenity report fixes

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -58,7 +58,7 @@ withNightlyPipeline(type, product, component) {
 
   after('fullFunctionalTest') {
     steps.sh 'ls -AlR .'
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/**/*'
   }
 
   after('mutationTest') {

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -53,6 +53,7 @@ withNightlyPipeline(type, product, component) {
   }
 
   after('fullFunctionalTest') {
+    steps.sh 'ls -AlR .'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
   }
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -57,7 +57,6 @@ withNightlyPipeline(type, product, component) {
   }
 
   after('fullFunctionalTest') {
-    steps.sh 'ls -AlR .'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/**/*'
   }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/AddCaseForPcqTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/AddCaseForPcqTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 @Slf4j
 public class AddCaseForPcqTest extends PcqBaseFunctionalTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/CreatePcqAnswersTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/CreatePcqAnswersTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 @Slf4j
 public class CreatePcqAnswersTest extends PcqBaseFunctionalTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/EndpointSecurityTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/EndpointSecurityTest.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ActiveProfiles;
@@ -9,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 public class EndpointSecurityTest extends PcqBaseFunctionalTest {
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/OptOutPcqAnswersTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/OptOutPcqAnswersTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 @Slf4j
 public class OptOutPcqAnswersTest extends PcqBaseFunctionalTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqAnswersErrorResponseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqAnswersErrorResponseTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 @Slf4j
 public class PcqAnswersErrorResponseTest extends PcqBaseFunctionalTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqBaseFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqBaseFunctionalTest.java
@@ -6,6 +6,8 @@ import io.restassured.parsing.Parser;
 import io.restassured.specification.RequestSpecification;
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,6 +30,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ComponentScan("uk.gov.hmcts.reform.pcqbackend")
 @TestPropertySource("classpath:application-functional.yaml")
 @Slf4j

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqRecordWithoutCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqRecordWithoutCaseTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 @Slf4j
 public class PcqRecordWithoutCaseTest extends PcqBaseFunctionalTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqWithoutCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/PcqWithoutCaseTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -18,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 @Slf4j
 public class PcqWithoutCaseTest extends PcqBaseFunctionalTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/SasTokenControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/SasTokenControllerTest.java
@@ -6,6 +6,8 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.core.PathUtility;
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.util.DateUtil;
 import org.junit.Before;
@@ -29,6 +31,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @Configuration
 @SpringBootTest
 @ComponentScan("uk.gov.hmcts.reform.pcqbackend")

--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/UpdatePcqAnswersTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/UpdatePcqAnswersTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Functional")})
 @ActiveProfiles("functional")
 @Slf4j
 public class UpdatePcqAnswersTest extends PcqBaseFunctionalTest {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/AddCaseForPcqTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/AddCaseForPcqTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Integration")})
 public class AddCaseForPcqTest extends PcqIntegrationTest {
 
     public static final String RESPONSE_KEY_1 = "pcqId";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/CreatePcqRequestTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/CreatePcqRequestTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Integration")})
 public class CreatePcqRequestTest extends PcqIntegrationTest {
 
     public static final String RESPONSE_KEY_1 = "pcqId";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqRecordWithoutCaseTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Integration")})
 @SuppressWarnings("PMD.LinguisticNaming")
 public class GetPcqRecordWithoutCaseTest extends PcqIntegrationTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqWithoutCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/GetPcqWithoutCaseTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Integration")})
 @SuppressWarnings("PMD.LinguisticNaming")
 public class GetPcqWithoutCaseTest extends PcqIntegrationTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/OptOutPcqRequestTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/OptOutPcqRequestTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Integration")})
 public class OptOutPcqRequestTest extends PcqIntegrationTest {
 
     public static final String RESPONSE_KEY_1 = "pcqId";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/SasTokenControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/SasTokenControllerTest.java
@@ -6,6 +6,8 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.core.PathUtility;
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Slf4j
 @TestPropertySource(locations = "/application.properties")
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Integration")})
 public class SasTokenControllerTest extends PcqIntegrationTest {
 
     public static final String SERVICE_BULKSCAN = "bulkscan";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/UpdatePcqRequestTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pcqbackend/controllers/UpdatePcqRequestTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.pcqbackend.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
+import net.thucydides.core.annotations.WithTag;
+import net.thucydides.core.annotations.WithTags;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @RunWith(SpringIntegrationSerenityRunner.class)
+@WithTags({@WithTag("testType:Integration")})
 @SuppressWarnings({"PMD.TooManyMethods"})
 public class UpdatePcqRequestTest extends PcqIntegrationTest {
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PCQ-636

### Change description ###

- Integration and functional tests are now separated by groups
- Fix the reporting output for Jenkins in the nightly build

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
