### PR TITLE
PCQ_744_Added suppression for the low severity CVE

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,4 +36,11 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: guava-29.0-jre.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+    <cve>CVE-2020-8908</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-744


### Change description ###
Added suppression for the CVE-2020-8908 as its a low severity. The library and its functions are not used in the pcq-backend  code.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
