### PR TITLE
PCQ-1141: Update spring-cloud-starter-netflix-hystrix to version 2.2.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,7 +347,7 @@ dependencies {
 
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap'
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.7.RELEASE'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.10.RELEASE'
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.0.5'
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/PCQ-1141

### Change description ###
- Update spring-cloud-starter-netflix-hystrix to version 2.2.10 as documented here: https://tanzu.vmware.com/security/cve-2021-22053
- Verified dependencyCheckAggregate passes locally and functional test is same result as without this fix.
- See also screenshots attached to Jira ticket.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```
