### PR TITLE
PCQ‐1134: Fix for task ':processResources' uses output of task ':generrateGitProperties' without declaring an explicit or implicit dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -478,3 +478,7 @@ rootProject.tasks.named("processIntegrationTestResources") {
 rootProject.tasks.named("processSmokeTestResources") {
   duplicatesStrategy = 'include'
 }
+
+rootProject.tasks.named("processResources") {
+  dependsOn("generateGitProperties")
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-1134

### Change description ###
Fix for task ':processResources' uses output of task ':generateGitProperties' without declaring an explicit or implicit dependency.
Ensures that Gradle task ':generateGitProperties' runs before task ':processResources'.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```