### PR TITLE
PCQ-1373-Dependency-check-netty-CVE-2022-24823

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ dependencyManagement {
   dependencies {
     // CVE-2021-21290
     dependency group: 'com.azure', name: 'azure-core-http-netty', version: '1.11.7'
-    dependencySet(group: 'io.netty', version: '4.1.74.Final') {
+    dependencySet(group: 'io.netty', version: '4.1.77.Final') {
       entry 'netty-buffer'
       entry 'netty-codec'
       entry 'netty-codec-http'
@@ -242,6 +242,9 @@ dependencyManagement {
       entry 'netty-codec-dns'
       entry 'netty-resolver-dns'
       entry 'netty-resolver-dns-native-macos'
+      entry 'netty-resolver-dns-classes-macos'
+      entry 'netty-transport-classes-epoll'
+      entry 'netty-transport-classes-kqueue'
     }
     dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.70'
     // CVE-2018-10237 - Unbounded memory allocation


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/PCQ-1373

### Change description ###
Fix dependency check CVE-2022-24823 , upgrade io.netty to version 4.1.77

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```