### PR TITLE
PCQ-1623 fixing Suppression CVE-2021-37533

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -382,6 +382,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'pcq-commons', version: '1.1.5'
   implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
+  implementation group: 'commons-net', name: 'commons-net', version: '3.9.0'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.fasterXmlJackson
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.fasterXmlJackson

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -10,7 +10,6 @@
     <cve>CVE-2022-22968</cve>
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2022-22978</cve>
-    <cve>CVE-2021-37533</cve>
   </suppress>
   <suppress>
     <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@.*$</packageUrl>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-1623


### Change description ###
This change is to remove suppression for CVE-2021-37533


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
