### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -356,7 +356,7 @@ dependencies {
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.19.1'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
 
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '5.1.9'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.